### PR TITLE
스프링 AOP 포인트컷

### DIFF
--- a/aop/src/main/java/hello/aop/member/MemberService.java
+++ b/aop/src/main/java/hello/aop/member/MemberService.java
@@ -1,0 +1,7 @@
+package hello.aop.member;
+
+public interface MemberService {
+
+	String hello(String param);
+
+}

--- a/aop/src/main/java/hello/aop/member/MemberServiceImpl.java
+++ b/aop/src/main/java/hello/aop/member/MemberServiceImpl.java
@@ -1,0 +1,22 @@
+package hello.aop.member;
+
+import org.springframework.stereotype.Component;
+
+import hello.aop.member.annotation.ClassAop;
+import hello.aop.member.annotation.MethodAop;
+
+@ClassAop
+@Component
+public class MemberServiceImpl implements MemberService {
+
+	@Override
+	@MethodAop("test value")
+	public String hello(String param) {
+		return "ok";
+	}
+
+	public String internal(String param) {
+		return "ok";
+	}
+
+}

--- a/aop/src/main/java/hello/aop/member/annotation/ClassAop.java
+++ b/aop/src/main/java/hello/aop/member/annotation/ClassAop.java
@@ -1,0 +1,11 @@
+package hello.aop.member.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ClassAop {
+}

--- a/aop/src/main/java/hello/aop/member/annotation/MethodAop.java
+++ b/aop/src/main/java/hello/aop/member/annotation/MethodAop.java
@@ -1,0 +1,14 @@
+package hello.aop.member.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface MethodAop {
+
+	String value();
+
+}

--- a/aop/src/test/java/hello/aop/pointcut/ArgsTest.java
+++ b/aop/src/test/java/hello/aop/pointcut/ArgsTest.java
@@ -1,0 +1,68 @@
+package hello.aop.pointcut;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.aop.aspectj.AspectJExpressionPointcut;
+
+import hello.aop.member.MemberServiceImpl;
+
+public class ArgsTest {
+
+	Method helloMethod;
+
+	@BeforeEach
+	public void init() throws NoSuchMethodException {
+		helloMethod = MemberServiceImpl.class.getMethod("hello", String.class);
+	}
+
+	private AspectJExpressionPointcut pointcut(String expression) {
+		AspectJExpressionPointcut pointcut = new AspectJExpressionPointcut();
+		pointcut.setExpression(expression);
+		return pointcut;
+	}
+
+	@Test
+	void args() {
+		//hello(String)과 매칭
+		assertThat(pointcut("args(String)")
+			.matches(helloMethod, MemberServiceImpl.class)).isTrue();
+		assertThat(pointcut("args(Object)")
+			.matches(helloMethod, MemberServiceImpl.class)).isTrue();
+		assertThat(pointcut("args()")
+			.matches(helloMethod, MemberServiceImpl.class)).isFalse();
+		assertThat(pointcut("args(..)")
+			.matches(helloMethod, MemberServiceImpl.class)).isTrue();
+		assertThat(pointcut("args(*)")
+			.matches(helloMethod, MemberServiceImpl.class)).isTrue();
+		assertThat(pointcut("args(String, ..)")
+			.matches(helloMethod, MemberServiceImpl.class)).isTrue();
+	}
+
+	/**
+	 * execution(* *(java.io.Serializable)): 메서드의 시그니처로 판단 (정적 판단)
+	 * args(java.io.Serializable): 런타임에 전달된 인수로 판단 (동적 판단)
+	 */
+	@Test
+	void argsVsExecution() {
+		// args
+		assertThat(pointcut("args(String)")
+			.matches(helloMethod, MemberServiceImpl.class)).isTrue();
+		assertThat(pointcut("args(java.io.Serializable)")
+			.matches(helloMethod, MemberServiceImpl.class)).isTrue();
+		assertThat(pointcut("args(Object)")
+			.matches(helloMethod, MemberServiceImpl.class)).isTrue();
+
+		// execution
+		assertThat(pointcut("execution(* *(String))")
+			.matches(helloMethod, MemberServiceImpl.class)).isTrue();
+		assertThat(pointcut("execution(* *(java.io.Serializable))") //매칭 실패
+			.matches(helloMethod, MemberServiceImpl.class)).isFalse();
+		assertThat(pointcut("execution(* *(Object))") // 매칭 실패
+			.matches(helloMethod, MemberServiceImpl.class)).isFalse();
+	}
+
+}

--- a/aop/src/test/java/hello/aop/pointcut/AtAnnotationTest.java
+++ b/aop/src/test/java/hello/aop/pointcut/AtAnnotationTest.java
@@ -1,0 +1,40 @@
+package hello.aop.pointcut;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+
+import hello.aop.member.MemberService;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Import({AtAnnotationTest.AtAnnotationAspect.class})
+@SpringBootTest
+public class AtAnnotationTest {
+
+	@Autowired
+	MemberService memberService;
+
+	@Test
+	void success() {
+		log.info("memberService Proxy={}", memberService.getClass());
+		memberService.hello("helloA");
+	}
+
+	@Slf4j
+	@Aspect
+	static class AtAnnotationAspect {
+
+		@Around("@annotation(hello.aop.member.annotation.MethodAop)")
+		public Object doAtAnnotation(ProceedingJoinPoint joinPoint) throws Throwable {
+			log.info("[@annotation] {}", joinPoint.getSignature());
+			return joinPoint.proceed();
+		}
+
+	}
+
+}

--- a/aop/src/test/java/hello/aop/pointcut/AtTargetAtWithinTest.java
+++ b/aop/src/test/java/hello/aop/pointcut/AtTargetAtWithinTest.java
@@ -1,0 +1,85 @@
+package hello.aop.pointcut;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+
+import hello.aop.member.annotation.ClassAop;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Import({AtTargetAtWithinTest.Config.class})
+@SpringBootTest
+public class AtTargetAtWithinTest {
+
+	@Autowired
+	Child child;
+
+	@Test
+	void test() {
+		log.info("child proxy={}", child.getClass());
+		child.childMethod(); // 부모, 자식 모두 있는 메서드
+		child.parentMethod(); // 부모 클래스만 있는 메서드
+	}
+
+	static class Config {
+
+		@Bean
+		public Parent parent() {
+			return new Parent();
+		}
+
+		@Bean
+		public Child child() {
+			return new Child();
+		}
+
+		@Bean
+		public AtTargetWithinAspect atTargetWithinAspect() {
+			return new AtTargetWithinAspect();
+		}
+
+	}
+
+	static class Parent {
+
+		public void parentMethod() {
+			// 부모에만 있는 메서드
+		}
+
+	}
+
+	@ClassAop
+	static class Child extends Parent {
+
+		public void childMethod() {
+		}
+
+	}
+
+	@Slf4j
+	@Aspect
+	static class AtTargetWithinAspect {
+
+		// @target: 인스턴스 기준으로 모든 메서드의 조인 포인트를 선정, 부모 타입의 메서드도 적용
+		@Around("execution(* hello.aop..*(..)) && @target(hello.aop.member.annotation.ClassAop)")
+		public Object atTarget(ProceedingJoinPoint joinPoint) throws Throwable {
+			log.info("[@target] {}", joinPoint.getSignature());
+			return joinPoint.proceed();
+		}
+
+		// @within: 선택된 클래스 내부에 있는 메서드만 조인 포인트로 선정, 부모 타입의 메서드는 적용되지 않음
+		@Around("execution(* hello.aop..*(..)) && @within(hello.aop.member.annotation.ClassAop)")
+		public Object atWithin(ProceedingJoinPoint joinPoint) throws Throwable {
+			log.info("[@within] {}", joinPoint.getSignature());
+			return joinPoint.proceed();
+		}
+
+	}
+
+}

--- a/aop/src/test/java/hello/aop/pointcut/BeanTest.java
+++ b/aop/src/test/java/hello/aop/pointcut/BeanTest.java
@@ -1,0 +1,38 @@
+package hello.aop.pointcut;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+
+import hello.aop.order.OrderService;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Import(BeanTest.BeanAspect.class)
+@SpringBootTest
+public class BeanTest {
+
+	@Autowired
+	OrderService orderService;
+
+	@Test
+	void success() {
+		orderService.orderItem("itemA");
+	}
+
+	@Aspect
+	static class BeanAspect {
+
+		@Around("bean(orderService) || bean(*Repository)")
+		public Object doLog(ProceedingJoinPoint joinPoint) throws Throwable {
+			log.info("[bean] {}", joinPoint.getSignature());
+			return joinPoint.proceed();
+		}
+
+	}
+
+}

--- a/aop/src/test/java/hello/aop/pointcut/ExecutionTest.java
+++ b/aop/src/test/java/hello/aop/pointcut/ExecutionTest.java
@@ -44,4 +44,29 @@ public class ExecutionTest {
 		assertThat(pointcut.matches(helloMethod, MemberServiceImpl.class)).isTrue();
 	}
 
+	// 이름 매칭
+	@Test
+	void nameMatch() {
+		pointcut.setExpression("execution(* hello(..))");
+		assertThat(pointcut.matches(helloMethod, MemberServiceImpl.class)).isTrue();
+	}
+
+	@Test
+	void nameMatchStar1() {
+		pointcut.setExpression("execution(* hel*(..))");
+		assertThat(pointcut.matches(helloMethod, MemberServiceImpl.class)).isTrue();
+	}
+
+	@Test
+	void nameMatchStar2() {
+		pointcut.setExpression("execution(* *el*(..))");
+		assertThat(pointcut.matches(helloMethod, MemberServiceImpl.class)).isTrue();
+	}
+
+	@Test
+	void nameMatchFalse() {
+		pointcut.setExpression("execution(* hi(..))");
+		assertThat(pointcut.matches(helloMethod, MemberServiceImpl.class)).isFalse();
+	}
+
 }

--- a/aop/src/test/java/hello/aop/pointcut/ExecutionTest.java
+++ b/aop/src/test/java/hello/aop/pointcut/ExecutionTest.java
@@ -113,4 +113,22 @@ public class ExecutionTest {
 		assertThat(pointcut.matches(helloMethod, MemberServiceImpl.class)).isTrue();
 	}
 
+	@Test
+	void typeMatchInternal() throws NoSuchMethodException {
+		pointcut.setExpression("execution(* hello.aop.member.MemberServiceImpl.*(..))");
+
+		Method internalMethod = MemberServiceImpl.class.getMethod("internal", String.class);
+		assertThat(pointcut.matches(internalMethod, MemberServiceImpl.class)).isTrue();
+	}
+
+	// 부모 타입에 있는 메서드만 허용
+	// 포인트컷으로 지정한 MemberService 는 internal 이라는 이름의 메서드가 없다
+	@Test
+	void typeMatchNoSuperTypeMethodFalse() throws NoSuchMethodException {
+		pointcut.setExpression("execution(* hello.aop.member.MemberService.*(..))");
+
+		Method internalMethod = MemberServiceImpl.class.getMethod("internal", String.class);
+		assertThat(pointcut.matches(internalMethod, MemberServiceImpl.class)).isFalse();
+	}
+
 }

--- a/aop/src/test/java/hello/aop/pointcut/ExecutionTest.java
+++ b/aop/src/test/java/hello/aop/pointcut/ExecutionTest.java
@@ -36,3 +36,12 @@ public class ExecutionTest {
 		pointcut.setExpression("execution(public String hello.aop.member.MemberServiceImpl.hello(String))");
 		assertThat(pointcut.matches(helloMethod, MemberServiceImpl.class)).isTrue();
 	}
+
+	@Test
+	@DisplayName("가장 많이 생략한 포인트컷 매칭")
+	void allMatch() {
+		pointcut.setExpression("execution(* *(..))");
+		assertThat(pointcut.matches(helloMethod, MemberServiceImpl.class)).isTrue();
+	}
+
+}

--- a/aop/src/test/java/hello/aop/pointcut/ExecutionTest.java
+++ b/aop/src/test/java/hello/aop/pointcut/ExecutionTest.java
@@ -1,8 +1,11 @@
 package hello.aop.pointcut;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.lang.reflect.Method;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.aop.aspectj.AspectJExpressionPointcut;
 
@@ -26,4 +29,10 @@ public class ExecutionTest {
 		log.info("helloMethod={}", helloMethod);
 	}
 
-}
+	@Test
+	@DisplayName("가장 정확한 포인트컷 매칭")
+	void exactMatch() {
+		// public java.lang.String hello.aop.member.MemberServiceImpl.hello(java.lang.String)
+		pointcut.setExpression("execution(public String hello.aop.member.MemberServiceImpl.hello(String))");
+		assertThat(pointcut.matches(helloMethod, MemberServiceImpl.class)).isTrue();
+	}

--- a/aop/src/test/java/hello/aop/pointcut/ExecutionTest.java
+++ b/aop/src/test/java/hello/aop/pointcut/ExecutionTest.java
@@ -131,4 +131,44 @@ public class ExecutionTest {
 		assertThat(pointcut.matches(internalMethod, MemberServiceImpl.class)).isFalse();
 	}
 
+	// String 타입의 파라미터 허용
+	// (String)
+	@Test
+	void argsMatch() {
+		pointcut.setExpression("execution(* *(String))");
+		assertThat(pointcut.matches(helloMethod, MemberServiceImpl.class)).isTrue();
+	}
+
+	// 파라미터가 없어야 함
+	// ()
+	@Test
+	void argsMatchNoArgs() {
+		pointcut.setExpression("execution(* *())");
+		assertThat(pointcut.matches(helloMethod, MemberServiceImpl.class)).isFalse();
+	}
+
+	// 정확히 하나의 파라미터 허용, 모든 타입 허용
+	// (Xxx)
+	@Test
+	void argsMatchStar() {
+		pointcut.setExpression("execution(* *(*))");
+		assertThat(pointcut.matches(helloMethod, MemberServiceImpl.class)).isTrue();
+	}
+
+	// 숫자와 무관하게 모든 파라미터, 모든 타입 허용
+	// (), (Xxx), (Xxx, Xxx)
+	@Test
+	void argsMatchAll() {
+		pointcut.setExpression("execution(* *(..))");
+		assertThat(pointcut.matches(helloMethod, MemberServiceImpl.class)).isTrue();
+	}
+
+	// String 타입으로 시작, 숫자와 무관하게 모든 파라미터, 모든 타입 허용
+	// (String), (String, Xxx), (String, Xxx, Xxx) 허용
+	@Test
+	void argsMatchComplex() {
+		pointcut.setExpression("execution(* *(String, ..))");
+		assertThat(pointcut.matches(helloMethod, MemberServiceImpl.class)).isTrue();
+	}
+
 }

--- a/aop/src/test/java/hello/aop/pointcut/ExecutionTest.java
+++ b/aop/src/test/java/hello/aop/pointcut/ExecutionTest.java
@@ -69,4 +69,35 @@ public class ExecutionTest {
 		assertThat(pointcut.matches(helloMethod, MemberServiceImpl.class)).isFalse();
 	}
 
+	// 패키지 매칭
+	@Test
+	void packageExactMatch1() {
+		pointcut.setExpression("execution(* hello.aop.member.MemberServiceImpl.hello(..))");
+		assertThat(pointcut.matches(helloMethod, MemberServiceImpl.class)).isTrue();
+	}
+
+	@Test
+	void packageExactMatch2() {
+		pointcut.setExpression("execution(* hello.aop.member.*.*(..))");
+		assertThat(pointcut.matches(helloMethod, MemberServiceImpl.class)).isTrue();
+	}
+
+	@Test
+	void packageExactFalse() {
+		pointcut.setExpression("execution(* hello.aop.*.*(..))");
+		assertThat(pointcut.matches(helloMethod, MemberServiceImpl.class)).isFalse();
+	}
+
+	@Test
+	void packageMatchSubPackage1() {
+		pointcut.setExpression("execution(* hello.aop.member..*.*(..))");
+		assertThat(pointcut.matches(helloMethod, MemberServiceImpl.class)).isTrue();
+	}
+
+	@Test
+	void packageMatchSubPackage2() {
+		pointcut.setExpression("execution(* hello.aop..*.*(..))");
+		assertThat(pointcut.matches(helloMethod, MemberServiceImpl.class)).isTrue();
+	}
+
 }

--- a/aop/src/test/java/hello/aop/pointcut/ExecutionTest.java
+++ b/aop/src/test/java/hello/aop/pointcut/ExecutionTest.java
@@ -100,4 +100,17 @@ public class ExecutionTest {
 		assertThat(pointcut.matches(helloMethod, MemberServiceImpl.class)).isTrue();
 	}
 
+	@Test
+	void typeExactMatch() {
+		pointcut.setExpression("execution(* hello.aop.member.MemberServiceImpl.*(..))");
+		assertThat(pointcut.matches(helloMethod, MemberServiceImpl.class)).isTrue();
+	}
+
+	@Test
+	@DisplayName("부모 타입 매칭")
+	void typeMatchSuperType() {
+		pointcut.setExpression("execution(* hello.aop.member.MemberService.*(..))");
+		assertThat(pointcut.matches(helloMethod, MemberServiceImpl.class)).isTrue();
+	}
+
 }

--- a/aop/src/test/java/hello/aop/pointcut/ExecutionTest.java
+++ b/aop/src/test/java/hello/aop/pointcut/ExecutionTest.java
@@ -1,0 +1,29 @@
+package hello.aop.pointcut;
+
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.aop.aspectj.AspectJExpressionPointcut;
+
+import hello.aop.member.MemberServiceImpl;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class ExecutionTest {
+
+	AspectJExpressionPointcut pointcut = new AspectJExpressionPointcut();
+	Method helloMethod;
+
+	@BeforeEach
+	public void init() throws NoSuchMethodException {
+		helloMethod = MemberServiceImpl.class.getMethod("hello", String.class);
+	}
+
+	@Test
+	void printMethod() {
+		// helloMethod=public java.lang.String hello.aop.member.MemberServiceImpl.hello(java.lang.String)
+		log.info("helloMethod={}", helloMethod);
+	}
+
+}

--- a/aop/src/test/java/hello/aop/pointcut/ParameterTest.java
+++ b/aop/src/test/java/hello/aop/pointcut/ParameterTest.java
@@ -1,0 +1,86 @@
+package hello.aop.pointcut;
+
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.annotation.Pointcut;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+
+import hello.aop.member.MemberService;
+import hello.aop.member.annotation.ClassAop;
+import hello.aop.member.annotation.MethodAop;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Import(ParameterTest.ParameterAspect.class)
+@SpringBootTest
+public class ParameterTest {
+
+	@Autowired
+	MemberService memberService;
+
+	@Test
+	void success() {
+		log.info("memberService Proxy={}", memberService.getClass());
+		memberService.hello("helloA");
+	}
+
+	@Slf4j
+	@Aspect
+	static class ParameterAspect {
+
+		@Pointcut("execution(* hello.aop.member..*.*(..))")
+		private void allMember() {
+		}
+
+		@Around("allMember()")
+		public Object logArgs1(ProceedingJoinPoint joinPoint) throws Throwable {
+			Object arg1 = joinPoint.getArgs()[0];
+			log.info("[logArgs1]{}, arg={}", joinPoint.getSignature(), arg1);
+			return joinPoint.proceed();
+		}
+
+		@Around("allMember() && args(arg, ..)")
+		public Object logArgs2(ProceedingJoinPoint joinPoint, Object arg) throws Throwable {
+			log.info("[logArgs2]{}, arg={}", joinPoint.getSignature(), arg);
+			return joinPoint.proceed();
+		}
+
+		@Before("allMember() && args(arg, ..)")
+		public void logArgs3(String arg) throws Throwable {
+			log.info("[logArgs3] arg={}", arg);
+		}
+
+		@Before("allMember() && this(obj)")
+		public void thisArgs(JoinPoint joinPoint, MemberService obj) {
+			log.info("[this]{}, obj={}", joinPoint.getSignature(), obj.getClass());
+		}
+
+		@Before("allMember() && target(obj)")
+		public void targetArgs(JoinPoint joinPoint, MemberService obj) {
+			log.info("[target]{}, obj={}", joinPoint.getSignature(), obj.getClass());
+		}
+
+		@Before("allMember() && @target(annotation)")
+		public void atTarget(JoinPoint joinPoint, ClassAop annotation) {
+			log.info("[@target]{}, obj={}", joinPoint.getSignature(), annotation);
+		}
+
+		@Before("allMember() && @within(annotation)")
+		public void atWithin(JoinPoint joinPoint, ClassAop annotation) {
+			log.info("[@within]{}, obj={}", joinPoint.getSignature(), annotation);
+		}
+
+		@Before("allMember() && @annotation(annotation)")
+		public void atAnnotation(JoinPoint joinPoint, MethodAop annotation) {
+			log.info("[@annotation]{}, annotationValue={}", joinPoint.getSignature(), annotation.value());
+		}
+
+	}
+
+}

--- a/aop/src/test/java/hello/aop/pointcut/ThisTargetTest.java
+++ b/aop/src/test/java/hello/aop/pointcut/ThisTargetTest.java
@@ -1,0 +1,61 @@
+package hello.aop.pointcut;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+
+import hello.aop.member.MemberService;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Import(ThisTargetTest.ThisTargetAspect.class)
+@SpringBootTest(properties = "spring.aop.proxy-target-class=false") // JDK 동적 프록시
+// @SpringBootTest(properties = "spring.aop.proxy-target-class=true") // CGLIB, 생략 가능
+public class ThisTargetTest {
+
+	@Autowired
+	MemberService memberService;
+
+	@Test
+	void success() {
+		log.info("memberService Proxy={}", memberService.getClass());
+		memberService.hello("helloA");
+	}
+
+	@Slf4j
+	@Aspect
+	static class ThisTargetAspect {
+
+		// 부모 타입 허용
+		@Around("this(hello.aop.member.MemberService)")
+		public Object doThisInterface(ProceedingJoinPoint joinPoint) throws Throwable {
+			log.info("[this-interface] {}", joinPoint.getSignature());
+			return joinPoint.proceed();
+		}
+
+		// 부모 타입 허용
+		@Around("target(hello.aop.member.MemberService)")
+		public Object doTargetInterface(ProceedingJoinPoint joinPoint) throws Throwable {
+			log.info("[target-interface] {}", joinPoint.getSignature());
+			return joinPoint.proceed();
+		}
+
+		@Around("this(hello.aop.member.MemberServiceImpl)")
+		public Object doThis(ProceedingJoinPoint joinPoint) throws Throwable {
+			log.info("[this-impl] {}", joinPoint.getSignature());
+			return joinPoint.proceed();
+		}
+
+		@Around("target(hello.aop.member.MemberServiceImpl)")
+		public Object doTarget(ProceedingJoinPoint joinPoint) throws Throwable {
+			log.info("[target-impl] {}", joinPoint.getSignature());
+			return joinPoint.proceed();
+		}
+
+	}
+
+}

--- a/aop/src/test/java/hello/aop/pointcut/WithinTest.java
+++ b/aop/src/test/java/hello/aop/pointcut/WithinTest.java
@@ -1,0 +1,56 @@
+package hello.aop.pointcut;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.aop.aspectj.AspectJExpressionPointcut;
+
+import hello.aop.member.MemberServiceImpl;
+
+public class WithinTest {
+
+	AspectJExpressionPointcut pointcut = new AspectJExpressionPointcut();
+	Method helloMethod;
+
+	@BeforeEach
+	void init() throws NoSuchMethodException {
+		helloMethod = MemberServiceImpl.class.getMethod("hello", String.class);
+	}
+
+	@Test
+	void withinExact() {
+		pointcut.setExpression("within(hello.aop.member.MemberServiceImpl)");
+		assertThat(pointcut.matches(helloMethod, MemberServiceImpl.class)).isTrue();
+	}
+
+	@Test
+	void withinStar() {
+		pointcut.setExpression("within(hello.aop.member.*Service*)");
+		assertThat(pointcut.matches(helloMethod, MemberServiceImpl.class)).isTrue();
+	}
+
+	@Test
+	void withinSubPackage() {
+		pointcut.setExpression("within(hello.aop..*)");
+		assertThat(pointcut.matches(helloMethod, MemberServiceImpl.class)).isTrue();
+	}
+
+	@Test
+	@DisplayName("타겟의 타입에만 직접 적용, 인터페이스를 선정하면 안된다")
+	void withinSuperTypeFalse() {
+		pointcut.setExpression("within(hello.aop.member.MemberService)");
+		assertThat(pointcut.matches(helloMethod, MemberServiceImpl.class)).isFalse();
+	}
+
+	@Test
+	@DisplayName("execution은 타입 기반, 인터페이스 선정 가능")
+	void executionSuperTypeTrue() {
+		pointcut.setExpression("execution(* hello.aop.member.MemberService.*(..))");
+		assertThat(pointcut.matches(helloMethod, MemberServiceImpl.class)).isTrue();
+	}
+
+}


### PR DESCRIPTION
- [x] 포인트컷 지시자
- [x] execution
- [x] within
- [x] args
- [x] `@target`, `@within`
- [x] `@annotation`, `@args`
- [x] bean
- [x] 매개변수 전달
- [x] this, target

This closes #69 